### PR TITLE
Use a new base version of Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-FROM hashicorp/packer:1.3.3
+FROM alpine:3.8
 LABEL maintainers="João Rosa <joaoasrosa@gmail.com>"
 
 ENV PACKER_VERSION=1.3.3
+ENV PACKER_SHA256SUM=efa311336db17c0709d5069509c34c35f0d59c63dfb05f61d4572c5a26b563ea
 ENV PACKER_PROVISIONER_GOSS_VERSION=0.3.0
+
+RUN apk add --update --repository http://dl-cdn.alpinelinux.org/alpine/edge/main git bash wget openssl
+
+ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
+ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./
+
+RUN sed -i '/.*linux_amd64.zip/!d' packer_${PACKER_VERSION}_SHA256SUMS
+RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
+RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
+RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 
 ADD https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${PACKER_PROVISIONER_GOSS_VERSION}/packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64 ./
 
-RUN apk add --upgrade --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main git=2.20.1-r0
 RUN mv ./packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64 /bin/packer-provisioner-goss
 RUN chmod +x /bin/packer-provisioner-goss
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PACKER_PROVISIONER_GOSS_VERSION=0.3.0
 
 ADD https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${PACKER_PROVISIONER_GOSS_VERSION}/packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64 ./
 
-RUN apk update && apk upgrade
+RUN apk add --upgrade --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main git=2.20.1-r0
 RUN mv ./packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64 /bin/packer-provisioner-goss
 RUN chmod +x /bin/packer-provisioner-goss
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainers="João Rosa <joaoasrosa@gmail.com>"
 ENV PACKER_VERSION=1.3.3
 ENV PACKER_PROVISIONER_GOSS_VERSION=0.3.0
 
-ADD https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${PACKER_PROVISIONER_GOSS_VERSION}/packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64
+ADD https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${PACKER_PROVISIONER_GOSS_VERSION}/packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64 ./
 
 RUN mv ./packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64 /bin/packer-provisioner-goss
 RUN chmod +x /bin/packer-provisioner-goss

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV PACKER_PROVISIONER_GOSS_VERSION=0.3.0
 
 ADD https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${PACKER_PROVISIONER_GOSS_VERSION}/packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64 ./
 
+RUN apk update && apk upgrade
 RUN mv ./packer-provisioner-goss-v${PACKER_PROVISIONER_GOSS_VERSION}-linux-amd64 /bin/packer-provisioner-goss
 RUN chmod +x /bin/packer-provisioner-goss
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,10 +16,10 @@ steps:
 - script: curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 && chmod +x container-structure-test-linux-amd64 && mkdir -p $HOME/bin && export PATH=$PATH:$HOME/bin && mv container-structure-test-linux-amd64 $HOME/bin/container-structure-test && container-structure-test test --image $(imageName) --config ./command-tests.yaml
   displayName: 'Run container tests'
 
-- script: mkdir ./node_modules && npm install --prefix ./ snyk && ./node_modules/.bin/snyk auth $(snyk-token) && ./node_modules/.bin/snyk test $(imageName) --docker --org=joaoasrosa --file=./Dockerfile
+- script: mkdir -p ./node_modules && npm install --prefix ./ snyk && ./node_modules/.bin/snyk auth $(snyk-token) && ./node_modules/.bin/snyk test $(imageName) --docker --org=joaoasrosa --file=./Dockerfile
   displayName: 'Scan for vulnerabilities in the Docker image'
 
-- script: ./node_modules/.bin/snyk auth $(snyk-token) && ./node_modules/.bin/snyk monitor $(imageName) --docker --org=joaoasrosa
+- script: mkdir -p ./node_modules && ./node_modules/.bin/snyk auth $(snyk-token) && ./node_modules/.bin/snyk monitor $(imageName) --docker --org=joaoasrosa
   displayName: 'Monitor vulnerabilities in the Docker image'
   condition: succeededOrFailed()
 

--- a/command-tests.yaml
+++ b/command-tests.yaml
@@ -22,4 +22,4 @@ commandTests:
   - name: "packer-provisioner-goss installation"
     command: "which"
     args: ["packer-provisioner-goss"]
-    expectedOutput: ["/usr/packer-provisioner-goss\n"]
+    expectedOutput: ["/bin/packer-provisioner-goss\n"]


### PR DESCRIPTION
This PR uses the latest version of the Alpine Linux. The base image from Hashicorp uses the `v3.7`, and it contains a bug which does not allow to update `git` to the latest version.

Using the `v3.8` we can use the latest `git` client, which does not contain vulnerabilities.